### PR TITLE
Improve performance by 30% by tweaking indexing/inlining

### DIFF
--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -205,7 +205,7 @@ impl DSFMTRng{
         self.idx = DSFMT_N64;
     }
 
-    #[inline]
+    #[inline(never)]
     fn gen_rand_all(&mut self){
         let mut lung = self.status[DSFMT_N];
         {

--- a/src/mt19937.rs
+++ b/src/mt19937.rs
@@ -236,10 +236,13 @@ impl DSFMTRng{
             self.idx = 0;
         }
 
-        let (n, m) = (self.idx / 2, self.idx % 2);
+        let n = self.idx;
         self.idx += 1;
 
-        self.status[n][m]
+        let v = unsafe {
+            mem::transmute::<_, &[u64, .. 2 * (DSFMT_N + 1)]>(&self.status)
+        };
+        v[n]
     }
 
     #[inline]


### PR DESCRIPTION
Before:

```
test bench_mt19937_1_000_000_rands ... bench:   2246224 ns/iter (+/- 103394)
```

After both:

```
test bench_mt19937_1_000_000_rands ... bench:   1567069 ns/iter (+/- 277793)
```
